### PR TITLE
Fixed some build issues. Really bad, non-obvious one still left.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,35 @@
 dist/*
 .DS_Store
+.cabal-sandbox
+cabal.sanbox.config
+cabal.config
+
+# emacs stuff
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# vim stuff
+*.swp
+*.swo
+
+

--- a/D3JS/Example.hs
+++ b/D3JS/Example.hs
@@ -18,7 +18,7 @@ import System.Random
 
 import Prelude hiding (id,(.))
 import Control.Category
-
+import D3JS.Preset
 -- * Examples
 
 test1, test2, test3 :: IO ()

--- a/d3js.cabal
+++ b/d3js.cabal
@@ -40,9 +40,9 @@ maintainer:          nebuta.office@gmail.com
 -- copyright:           
 category:            Graphics
 build-type:          Simple
--- extra-source-files:  
 stability: Experimental
 cabal-version:       >=1.10
+extra-source-files: test/Test.hs
 
 library
   exposed-modules:
@@ -62,7 +62,7 @@ library
   -- hs-source-dirs:      
   default-language:    Haskell2010
 
-Test-Suite spec
+Test-Suite test
   Type:                 exitcode-stdio-1.0
   Default-Language:     Haskell2010
   Hs-Source-Dirs:       test
@@ -74,4 +74,5 @@ Test-Suite spec
                       , QuickCheck
                       , d3js
                       , text
-
+                      , random
+                      , transformers

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,7 +2,7 @@
 
 {-# LANGUAGE OverloadedStrings,NoImplicitPrelude #-}
 
-module Example where
+module Main where
 
 import D3JS
 import Test.Hspec
@@ -44,7 +44,7 @@ tests = [("rects2d.html",rects2d)]
 
 objConst = DataParam :: NumFunc JSObjArray
 
-runAll = forM_ tests $ \(n,st) -> writeToHtml n st
+main = forM_ tests $ \(n,st) -> writeToHtml n st
 
 rand2D :: Int -> IO [(Double,Double)]
 rand2D n = do


### PR DESCRIPTION
Ouch.

aistis@localhost ~/projects/d3js-haskell (git)-[master] % cabal configure --enable-tests && cabal build && cabal test                                                                                                                                     :(
Resolving dependencies...
Configuring d3js-0.1.0.0...
Building d3js-0.1.0.0...
Preprocessing library d3js-0.1.0.0...
In-place registering d3js-0.1.0.0...
Preprocessing test suite 'test' for d3js-0.1.0.0...
Linking dist/build/test/test ...
dist/build/test/test-tmp/Main.o: In function `r4c2_info':
(.text+0xb0a): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwmkSvg_info'
dist/build/test/test-tmp/Main.o: In function `s4nm_info':
(.text+0x2b8c): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
dist/build/test/test-tmp/Main.o: In function `r4db_info':
(.text+0x3fd2): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwmkSvg_info'
dist/build/test/test-tmp/Main.o: In function `r4dc_info':
(.text+0x406d): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterDatazq_info'
dist/build/test/test-tmp/Main.o: In function `s4Dt_info':
(.text+0x72b4): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
dist/build/test/test-tmp/Main.o: In function `r4c2_srt':
(.data+0x340): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwmkSvg_closure'
dist/build/test/test-tmp/Main.o: In function `Main_rects4_srt':
(.data+0xbf0): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
dist/build/test/test-tmp/Main.o: In function `r4db_srt':
(.data+0xe88): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwmkSvg_closure'
dist/build/test/test-tmp/Main.o: In function `r4dc_srt':
(.data+0xeb8): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterDatazq_closure'
dist/build/test/test-tmp/Main.o: In function `Main_main5_srt':
(.data+0x1910): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.text+0x788c): undefined reference to `d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.text+0x8adc): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.text+0xe6dc): undefined reference to `d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.text+0xfe94): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_info'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.data+0x15d0): undefined reference to `d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.data+0x1ad0): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.data+0x33f0): undefined reference to `d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
/home/aistis/projects/d3js-haskell/dist/build/libHSd3js-0.1.0.0.a(Chart.o):(.data+0x3748): undefined reference to`d3jszm0zi1zi0zi0_D3JSziPreset_zdwenterData_closure'
collect2: error: ld returned 1 exit status
